### PR TITLE
Set Exception Value and Message of Event

### DIFF
--- a/Observer/BeforeSending.php
+++ b/Observer/BeforeSending.php
@@ -34,6 +34,8 @@ class BeforeSending implements ObserverInterface
         if ($hint?->exception instanceof LocalizedException) {
             $hintMessage = $hint->exception->getRawMessage();
             $event->setMessage($hintMessage);
+            $event->getExceptions()[0]->setValue($hintMessage);
+            $observer->getEvent()->getSentryEvent()->setEvent($event);
         }
 
         $messages = $this->json->unserialize($this->scopeConfig->getValue('sentry/event_filtering/messages'));


### PR DESCRIPTION
The event message was not properly returned and I also updated the exception value since that was still localized and could give the wrong message in Sentry. 

Updating the exception value was based on feedback from https://github.com/getsentry/sentry-javascript/issues/3204