### PR TITLE
Improved LocalizedException filterability and readability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+.idea
+composer.lock
+/vendor

--- a/composer.json
+++ b/composer.json
@@ -9,20 +9,35 @@
   },
   "authors": [
     {
-        "name": "Robin Mulder",
-        "email": "robin@justbetter.nl",
-        "homepage": "https://justbetter.nl",
-        "role": "Developer"
+      "name": "Robin Mulder",
+      "email": "robin@justbetter.nl",
+      "homepage": "https://justbetter.nl",
+      "role": "Developer"
     },
-      {
-        "name": "Indy Koning",
-        "email": "indy@justbetter.nl",
-        "homepage": "https://justbetter.nl",
-        "role": "Developer"
-      }
+    {
+      "name": "Indy Koning",
+      "email": "indy@justbetter.nl",
+      "homepage": "https://justbetter.nl",
+      "role": "Developer"
+    }
   ],
+  "repositories": {
+    "magento": {
+      "type": "composer",
+      "url": "https://repo-magento-mirror.fooman.co.nz/"
+    }
+  },
   "autoload": {
-    "psr-4": { "JustBetter\\SentryFilterEvents\\": "" },
-    "files": [ "registration.php" ]
+    "psr-4": {
+      "JustBetter\\SentryFilterEvents\\": ""
+    },
+    "files": [
+      "registration.php"
+    ]
+  },
+  "config": {
+    "allow-plugins": {
+      "magento/composer-dependency-version-audit-plugin": true
+    }
   }
 }


### PR DESCRIPTION
This PR sets the logMessage as exception message instead of rawMessage, the benefit is that variables are already filled in in the string.
With this an additional message context gets attached, with the raw message, parameters, log message and translated message.

This also helps in ignoring errors as now we check the hint message, but the raw message as well.
The entire translation can now be passed to ignore the message.